### PR TITLE
Yivanov/require

### DIFF
--- a/src/merger/src/binary/binaryHashtable.cpp
+++ b/src/merger/src/binary/binaryHashtable.cpp
@@ -29,7 +29,7 @@ unsigned int binary::BinaryHashtable::size() {
     return (unsigned int) this->elements.size();
 }
 
-std::vector<binary::MetaFileOffset> binary::BinaryHashtable::serialize(binary::BinaryWriter& heapWriter) {
+std::vector<binary::MetaFileOffset> binary::BinaryHashtable::serialize(binary::BinaryWriter* heapWriter) {
     std::vector<binary::MetaFileOffset> offsets;
 
     for (std::vector<std::tuple<std::string, MetaFileOffset>> element : this->elements) {
@@ -39,7 +39,7 @@ std::vector<binary::MetaFileOffset> binary::BinaryHashtable::serialize(binary::B
                 elementOffsets.push_back(std::get<1>(tuple));
             }
 
-            offsets.push_back(heapWriter.push_binaryArray(elementOffsets));
+            offsets.push_back(heapWriter->push_binaryArray(elementOffsets));
         } else {
             offsets.push_back(0);
         }

--- a/src/merger/src/binary/binaryHashtable.h
+++ b/src/merger/src/binary/binaryHashtable.h
@@ -53,7 +53,7 @@ namespace binary {
          * \param heapWriter Reference to a \c BinaryWriter that will be used for serialization
          * \returns vector of offsets pointing to vectors in the heap
          */
-        std::vector<MetaFileOffset> serialize(BinaryWriter& heapWriter);
+        std::vector<MetaFileOffset> serialize(BinaryWriter* heapWriter);
     };
 }
 

--- a/src/merger/src/binary/binarySerializer.cpp
+++ b/src/merger/src/binary/binarySerializer.cpp
@@ -33,16 +33,21 @@ bool isInitMethod(meta::MethodMeta& meta) {
     return meta.name.substr(0, prefix.size()) == prefix;
 }
 
+string getTopLevelModule(const string& moduleName) {
+    int dotPosition = moduleName.find('.', 0);
+    return (dotPosition == string::npos) ? moduleName : moduleName.substr(0, dotPosition);
+}
+
 void binary::BinarySerializer::serializeBase(meta::Meta* meta, binary::Meta& binaryMetaStruct) {
     // name
     bool hasName = meta->name != meta->jsName;
     if (!hasName) {
-        binaryMetaStruct._names = this->heapWriter.push_string(meta->jsName);
+        binaryMetaStruct._names = this->heapWriter->push_string(meta->jsName);
     } else {
-        MetaFileOffset offset1 = this->heapWriter.push_string(meta->jsName);
-        MetaFileOffset offset2 = this->heapWriter.push_string(meta->name);
-        binaryMetaStruct._names = this->heapWriter.push_pointer(offset1);
-        this->heapWriter.push_pointer(offset2);
+        MetaFileOffset offset1 = this->heapWriter->push_string(meta->jsName);
+        MetaFileOffset offset2 = this->heapWriter->push_string(meta->name);
+        binaryMetaStruct._names = this->heapWriter->push_pointer(offset1);
+        this->heapWriter->push_pointer(offset2);
     }
 
     // flags
@@ -54,7 +59,7 @@ void binary::BinarySerializer::serializeBase(meta::Meta* meta, binary::Meta& bin
     binaryMetaStruct._flags = flags;
 
     // module
-    binaryMetaStruct._frameworkId = (uint16_t)this->moduleMap[meta->module];
+    binaryMetaStruct._frameworkId = (uint16_t)this->moduleMap[getTopLevelModule(meta->module)];
 
     // introduced in
     binaryMetaStruct._introduced = convertVersion(meta->introducedIn);
@@ -70,9 +75,9 @@ void binary::BinarySerializer::serializeBaseClass(meta::BaseClassMeta *meta, bin
     for (meta::MethodMeta& methodMeta : meta->instanceMethods) {
         binary::MethodMeta binaryMeta;
         this->serializeMethod(&methodMeta, binaryMeta);
-        offsets.push_back(binaryMeta.save(this->heapWriter));
+        offsets.push_back(binaryMeta.save(this->heapWriter.get()));
     }
-    binaryMetaStruct._instanceMethods = offsets.size() > 0 ? this->heapWriter.push_binaryArray(offsets) : 0;
+    binaryMetaStruct._instanceMethods = offsets.size() > 0 ? this->heapWriter->push_binaryArray(offsets) : 0;
     offsets.clear();
 
     // static methods
@@ -80,9 +85,9 @@ void binary::BinarySerializer::serializeBaseClass(meta::BaseClassMeta *meta, bin
     for (meta::MethodMeta& methodMeta : meta->staticMethods) {
         binary::MethodMeta binaryMeta;
         this->serializeMethod(&methodMeta, binaryMeta);
-        offsets.push_back(binaryMeta.save(this->heapWriter));
+        offsets.push_back(binaryMeta.save(this->heapWriter.get()));
     }
-    binaryMetaStruct._staticMethods = offsets.size() > 0 ? this->heapWriter.push_binaryArray(offsets) : 0;
+    binaryMetaStruct._staticMethods = offsets.size() > 0 ? this->heapWriter->push_binaryArray(offsets) : 0;
     offsets.clear();
 
     // properties
@@ -90,17 +95,17 @@ void binary::BinarySerializer::serializeBaseClass(meta::BaseClassMeta *meta, bin
     for (meta::PropertyMeta& propertyMeta : meta->properties) {
         binary::PropertyMeta binaryMeta;
         this->serializeProperty(&propertyMeta, binaryMeta);
-        offsets.push_back(binaryMeta.save(this->heapWriter));
+        offsets.push_back(binaryMeta.save(this->heapWriter.get()));
     }
-    binaryMetaStruct._properties = offsets.size() > 0 ? this->heapWriter.push_binaryArray(offsets) : 0;
+    binaryMetaStruct._properties = offsets.size() > 0 ? this->heapWriter->push_binaryArray(offsets) : 0;
     offsets.clear();
 
     // protocols
     std::sort(meta->protocols.begin(), meta->protocols.end(), compareFQN);
     for (FQName& protocolName : meta->protocols) {
-        offsets.push_back(this->heapWriter.push_string(protocolName.name));
+        offsets.push_back(this->heapWriter->push_string(protocolName.name));
     }
-    binaryMetaStruct._protocols = offsets.size() > 0 ? this->heapWriter.push_binaryArray(offsets) : 0;
+    binaryMetaStruct._protocols = offsets.size() > 0 ? this->heapWriter->push_binaryArray(offsets) : 0;
     offsets.clear();
 
     // first initializer index
@@ -112,13 +117,13 @@ void binary::BinarySerializer::serializeBaseClass(meta::BaseClassMeta *meta, bin
 void binary::BinarySerializer::serializeMethod(meta::MethodMeta *meta, binary::MethodMeta &binaryMetaStruct) {
     this->serializeBase(meta, binaryMetaStruct);
 
-    binaryMetaStruct._selector = this->heapWriter.push_string(meta->selector);
+    binaryMetaStruct._selector = this->heapWriter->push_string(meta->selector);
     vector<typeEncoding::TypeEncoding*> typeEncodings;
     for (auto& encoding : meta->signature) {
         typeEncodings.push_back(encoding.get());
     }
     binaryMetaStruct._encoding = this->typeEncodingSerializer.serialize(typeEncodings);
-    binaryMetaStruct._compilerEncoding = this->heapWriter.push_string(meta->typeEncoding);
+    binaryMetaStruct._compilerEncoding = this->heapWriter->push_string(meta->typeEncoding);
 }
 
 void binary::BinarySerializer::serializeProperty(meta::PropertyMeta *meta, binary::PropertyMeta &binaryMetaStruct) {
@@ -127,12 +132,12 @@ void binary::BinarySerializer::serializeProperty(meta::PropertyMeta *meta, binar
     if ((meta->flags & meta::MetaFlags::PropertyHasGetter) == meta::MetaFlags::PropertyHasGetter) {
         binary::MethodMeta binaryMeta;
         this->serializeMethod(meta->getter.get(), binaryMeta);
-        binaryMetaStruct._getter = binaryMeta.save(this->heapWriter);
+        binaryMetaStruct._getter = binaryMeta.save(this->heapWriter.get());
     }
     if ((meta->flags & meta::MetaFlags::PropertyHasSetter) == meta::MetaFlags::PropertyHasSetter) {
         binary::MethodMeta binaryMeta;
         this->serializeMethod(meta->setter.get(), binaryMeta);
-        binaryMetaStruct._setter = binaryMeta.save(this->heapWriter);
+        binaryMetaStruct._setter = binaryMeta.save(this->heapWriter.get());
     }
 }
 
@@ -144,10 +149,10 @@ void binary::BinarySerializer::serializeRecord(meta::RecordMeta *meta, binary::R
 
     for (meta::RecordField& recordField : meta->fields) {
         typeEncodings.push_back(recordField.encoding.get());
-        nameOffsets.push_back(this->heapWriter.push_string(recordField.name));
+        nameOffsets.push_back(this->heapWriter->push_string(recordField.name));
     }
 
-    binaryMetaStruct._fieldNames = this->heapWriter.push_binaryArray(nameOffsets);
+    binaryMetaStruct._fieldNames = this->heapWriter->push_binaryArray(nameOffsets);
     binaryMetaStruct._fieldsEncodings = this->typeEncodingSerializer.serialize(typeEncodings);
 }
 
@@ -161,21 +166,14 @@ void binary::BinarySerializer::start(utils::MetaContainer *container) {
     // get all top level modules and write them down first
     set<string, CaseInsensitiveCompare> topLevelModules;
     for (auto moduleIter = container->beginModules(); moduleIter != container->endModules(); ++moduleIter) {
-        int dotPosition = moduleIter->find('.', 0);
-        if (dotPosition == string::npos) {
-            topLevelModules.emplace(*moduleIter);
-        } else {
-            topLevelModules.emplace(moduleIter->substr(0, dotPosition));
-        }
+        string topLevelModule = getTopLevelModule(*moduleIter);
+        topLevelModules.emplace(topLevelModule);
+
+        binary::MetaFileOffset offset = this->heapWriter->push_string(topLevelModule);
+        this->moduleMap.emplace(topLevelModule, offset);
     }
     vector<string> modulesVector(topLevelModules.begin(), topLevelModules.end());
     this->file->registerTopLevelModules(modulesVector);
-
-    // write all module names in heap and write down their offsets
-    for (auto moduleIter = container->beginModules(); moduleIter != container->endModules(); ++moduleIter) {
-        binary::MetaFileOffset offset = this->heapWriter.push_string(*moduleIter);
-        this->moduleMap.emplace(*moduleIter, offset);
-    }
 }
 
 void binary::BinarySerializer::finish(utils::MetaContainer *container) {
@@ -186,15 +184,15 @@ void binary::BinarySerializer::serialize(meta::InterfaceMeta* meta) {
     binary::InterfaceMeta binaryStruct;
     serializeBaseClass(meta, binaryStruct);
     if (!meta->baseName.isEmpty()) {
-        binaryStruct._baseName = this->heapWriter.push_string(meta->baseName.name);
+        binaryStruct._baseName = this->heapWriter->push_string(meta->baseName.name);
     }
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::ProtocolMeta* meta) {
     binary::ProtocolMeta binaryStruct;
     serializeBaseClass(meta, binaryStruct);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::CategoryMeta *meta) {
@@ -209,32 +207,32 @@ void binary::BinarySerializer::serialize(meta::FunctionMeta* meta) {
         typeEncodings.push_back(encoding.get());
     }
     binaryStruct._encoding = this->typeEncodingSerializer.serialize(typeEncodings);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::StructMeta* meta) {
     binary::StructMeta binaryStruct;
     serializeRecord(meta, binaryStruct);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::UnionMeta* meta) {
     binary::UnionMeta binaryStruct;
     serializeRecord(meta, binaryStruct);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::JsCodeMeta* meta) {
     binary::JsCodeMeta binaryStruct;
     serializeBase(meta, binaryStruct);
-    binaryStruct._jsCode = this->heapWriter.push_string(meta->jsCode);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    binaryStruct._jsCode = this->heapWriter->push_string(meta->jsCode);
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }
 
 void binary::BinarySerializer::serialize(meta::VarMeta* meta) {
     binary::VarMeta binaryStruct;
     serializeBase(meta, binaryStruct);
     unique_ptr<binary::TypeEncoding> binarySignature = meta->signature->serialize(&this->typeEncodingSerializer);
-    binaryStruct._encoding = binarySignature->save(this->heapWriter);
-    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter));
+    binaryStruct._encoding = binarySignature->save(this->heapWriter.get());
+    this->file->registerInGlobalTable(meta->jsName, binaryStruct.save(this->heapWriter.get()));
 }

--- a/src/merger/src/binary/binarySerializer.h
+++ b/src/merger/src/binary/binarySerializer.h
@@ -16,7 +16,7 @@ namespace binary {
     class BinarySerializer : public utils::Serializer {
     private:
         MetaFile* file;
-        BinaryWriter heapWriter;
+        std::shared_ptr<BinaryWriter> heapWriter;
         BinaryTypeEncodingSerializer typeEncodingSerializer;
         std::map<std::string, MetaFileOffset> moduleMap;
 

--- a/src/merger/src/binary/binaryStructures.cpp
+++ b/src/merger/src/binary/binaryStructures.cpp
@@ -1,132 +1,132 @@
 #include "binaryStructures.h"
 #include "metaFile.h"
 
-binary::MetaFileOffset binary::Meta::save(BinaryWriter& writer) {
-    binary::MetaFileOffset offset = writer.push_pointer(this->_names);
-    writer.push_byte(this->_flags);
-    writer.push_short(this->_frameworkId);
-    writer.push_byte(this->_introduced);
+binary::MetaFileOffset binary::Meta::save(BinaryWriter* writer) {
+    binary::MetaFileOffset offset = writer->push_pointer(this->_names);
+    writer->push_byte(this->_flags);
+    writer->push_short(this->_frameworkId);
+    writer->push_byte(this->_introduced);
     return offset;
 }
 
-binary::MetaFileOffset binary::JsCodeMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::JsCodeMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
-    writer.push_pointer(this->_jsCode);
+    writer->push_pointer(this->_jsCode);
     return offset;
 }
 
-binary::MetaFileOffset binary::RecordMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::RecordMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
-    writer.push_pointer(this->_fieldNames);
-    writer.push_pointer(this->_fieldsEncodings);
+    writer->push_pointer(this->_fieldNames);
+    writer->push_pointer(this->_fieldsEncodings);
     return offset;
 }
 
-binary::MetaFileOffset binary::FunctionMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::FunctionMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
-    writer.push_pointer(this->_encoding);
+    writer->push_pointer(this->_encoding);
     return offset;
 }
 
-binary::MetaFileOffset binary::VarMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::VarMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
-    writer.push_pointer(this->_encoding);
+    writer->push_pointer(this->_encoding);
     return offset;
 }
 
-binary::MetaFileOffset binary::MethodMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::MethodMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = MemberMeta::save(writer);
-    writer.push_pointer(this->_selector);
-    writer.push_pointer(this->_encoding);
-    writer.push_pointer(this->_compilerEncoding);
+    writer->push_pointer(this->_selector);
+    writer->push_pointer(this->_encoding);
+    writer->push_pointer(this->_compilerEncoding);
     return offset;
 }
 
-binary::MetaFileOffset binary::PropertyMeta::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::PropertyMeta::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
     if (this->_getter) {
-        writer.push_pointer(this->_getter);
+        writer->push_pointer(this->_getter);
     }
     if (this->_setter) {
-        writer.push_pointer(this->_setter);
+        writer->push_pointer(this->_setter);
     }
     return offset;
 }
 
-binary::MetaFileOffset binary::BaseClassMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::BaseClassMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = Meta::save(writer);
-    writer.push_pointer(this->_instanceMethods);
-    writer.push_pointer(this->_staticMethods);
-    writer.push_pointer(this->_properties);
-    writer.push_pointer(this->_protocols);
-    writer.push_short(this->_initializersStartIndex);
+    writer->push_pointer(this->_instanceMethods);
+    writer->push_pointer(this->_staticMethods);
+    writer->push_pointer(this->_properties);
+    writer->push_pointer(this->_protocols);
+    writer->push_short(this->_initializersStartIndex);
     return offset;
 }
 
-binary::MetaFileOffset binary::InterfaceMeta::save(BinaryWriter& writer) {
+binary::MetaFileOffset binary::InterfaceMeta::save(BinaryWriter* writer) {
     binary::MetaFileOffset offset = BaseClassMeta::save(writer);
-    writer.push_pointer(this->_baseName);
+    writer->push_pointer(this->_baseName);
     return offset;
 }
 
-binary::MetaFileOffset binary::TypeEncoding::save(binary::BinaryWriter &writer) {
-    return writer.push_byte(this->_type);
+binary::MetaFileOffset binary::TypeEncoding::save(binary::BinaryWriter* writer) {
+    return writer->push_byte(this->_type);
 }
 
-binary::MetaFileOffset binary::IncompleteArrayEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::IncompleteArrayEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
     this->_elementType->save(writer);
     return offset;
 }
 
-binary::MetaFileOffset binary::ConstantArrayEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::ConstantArrayEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_int(this->_size);
+    writer->push_int(this->_size);
     this->_elementType->save(writer);
     return offset;
 }
 
-binary::MetaFileOffset binary::DeclarationReferenceEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::DeclarationReferenceEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_pointer(this->_name);
+    writer->push_pointer(this->_name);
     return offset;
 }
 
-binary::MetaFileOffset binary::PointerEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::PointerEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
     this->_target->save(writer);
     return offset;
 }
 
-binary::MetaFileOffset binary::BlockEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::BlockEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_byte(this->_encodingsCount);
+    writer->push_byte(this->_encodingsCount);
     for (int i = 0; i < this->_encodingsCount; i++) {
         this->_encodings[i]->save(writer);
     }
     return offset;
 }
 
-binary::MetaFileOffset binary::FunctionEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::FunctionEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_byte(this->_encodingsCount);
+    writer->push_byte(this->_encodingsCount);
     for (int i = 0; i < this->_encodingsCount; i++) {
         this->_encodings[i]->save(writer);
     }
     return offset;
 }
 
-binary::MetaFileOffset binary::InterfaceDeclarationEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::InterfaceDeclarationEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_pointer(this->_name);
+    writer->push_pointer(this->_name);
     return offset;
 }
 
-binary::MetaFileOffset binary::AnonymousRecordEncoding::save(binary::BinaryWriter &writer) {
+binary::MetaFileOffset binary::AnonymousRecordEncoding::save(binary::BinaryWriter* writer) {
     binary::MetaFileOffset offset = TypeEncoding::save(writer);
-    writer.push_byte(this->_fieldsCount);
+    writer->push_byte(this->_fieldsCount);
     for (int i = 0; i < this->_fieldsCount; i++) {
-        writer.push_pointer(this->_fieldNames[i]);
+        writer->push_pointer(this->_fieldNames[i]);
     }
     for (int i = 0; i < this->_fieldsCount; i++) {
         this->_fieldEncodings[i]->save(writer);

--- a/src/merger/src/binary/binaryStructures.h
+++ b/src/merger/src/binary/binaryStructures.h
@@ -59,7 +59,7 @@ namespace binary {
         uint16_t _frameworkId = 0;
         uint8_t _introduced = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer);
+        virtual MetaFileOffset save(BinaryWriter* writer);
     };
 
     struct RecordMeta : Meta {
@@ -67,7 +67,7 @@ namespace binary {
         MetaFileOffset _fieldNames = 0;
         MetaFileOffset _fieldsEncodings = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct StructMeta : RecordMeta {
@@ -80,21 +80,21 @@ namespace binary {
     public:
         MetaFileOffset _encoding = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct JsCodeMeta : Meta {
     public:
         MetaFileOffset _jsCode = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct VarMeta : Meta {
     public:
         MetaFileOffset _encoding = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct MemberMeta : Meta {
@@ -106,14 +106,14 @@ namespace binary {
         MetaFileOffset _encoding = 0;
         MetaFileOffset _compilerEncoding = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct PropertyMeta : MemberMeta {
         MetaFileOffset _getter = 0;
         MetaFileOffset _setter = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct BaseClassMeta : Meta {
@@ -124,7 +124,7 @@ namespace binary {
         MetaFileOffset _protocols = 0;
         int16_t _initializersStartIndex = -1;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct ProtocolMeta : BaseClassMeta {
@@ -134,7 +134,7 @@ namespace binary {
     public:
         MetaFileOffset _baseName = 0;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 #pragma pack(pop)
 
@@ -146,7 +146,7 @@ namespace binary {
 
         BinaryTypeEncodingType _type;
 
-        virtual MetaFileOffset save(BinaryWriter& writer);
+        virtual MetaFileOffset save(BinaryWriter* writer);
     };
 
     struct IncompleteArrayEncoding : public TypeEncoding {
@@ -155,7 +155,7 @@ namespace binary {
 
         std::unique_ptr<TypeEncoding> _elementType;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct ConstantArrayEncoding : public TypeEncoding {
@@ -165,7 +165,7 @@ namespace binary {
         int _size;
         std::unique_ptr<TypeEncoding> _elementType;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct DeclarationReferenceEncoding : public TypeEncoding {
@@ -174,7 +174,7 @@ namespace binary {
 
         MetaFileOffset _name;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct PointerEncoding : public TypeEncoding {
@@ -183,7 +183,7 @@ namespace binary {
 
         std::unique_ptr<TypeEncoding> _target;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct BlockEncoding : public TypeEncoding {
@@ -193,7 +193,7 @@ namespace binary {
         uint8_t _encodingsCount;
         std::vector<std::unique_ptr<TypeEncoding>> _encodings;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct FunctionEncoding : public TypeEncoding {
@@ -203,7 +203,7 @@ namespace binary {
         uint8_t _encodingsCount;
         std::vector<std::unique_ptr<TypeEncoding>> _encodings;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct InterfaceDeclarationEncoding : public TypeEncoding {
@@ -212,7 +212,7 @@ namespace binary {
 
         MetaFileOffset _name;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 
     struct AnonymousRecordEncoding : public TypeEncoding {
@@ -223,7 +223,7 @@ namespace binary {
         std::vector<MetaFileOffset> _fieldNames;
         std::vector<std::unique_ptr<TypeEncoding>> _fieldEncodings;
 
-        virtual MetaFileOffset save(BinaryWriter& writer) override;
+        virtual MetaFileOffset save(BinaryWriter* writer) override;
     };
 }
 

--- a/src/merger/src/binary/binaryTypeEncodingSerializer.cpp
+++ b/src/merger/src/binary/binaryTypeEncodingSerializer.cpp
@@ -10,9 +10,9 @@ binary::MetaFileOffset binary::BinaryTypeEncodingSerializer::serialize(std::vect
             binaryEncodings.push_back(std::move(binaryEncoding));
         }
 
-        offset = this->_heapWriter.push_arrayCount(encodings.size());
+        offset = this->_heapWriter->push_arrayCount(encodings.size());
         for (unique_ptr<binary::TypeEncoding>& binaryEncoding : binaryEncodings) {
-            binaryEncoding->save(this->_heapWriter);
+            binaryEncoding->save(this->_heapWriter.get());
         }
     }
     return offset;
@@ -125,7 +125,7 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize(typeEncoding::InterfaceEncoding *encoding) {
     binary::DeclarationReferenceEncoding* s = new binary::DeclarationReferenceEncoding(BinaryTypeEncodingType::InterfaceDeclarationReference);
-    s->_name = this->_heapWriter.push_string(encoding->name.name);
+    s->_name = this->_heapWriter->push_string(encoding->name.name);
     return unique_ptr<binary::TypeEncoding>(s);
 }
 
@@ -155,19 +155,19 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize(typeEncoding::StructEncoding *encoding) {
     binary::DeclarationReferenceEncoding* s = new binary::DeclarationReferenceEncoding(BinaryTypeEncodingType::StructDeclarationReference);
-    s->_name = this->_heapWriter.push_string(encoding->name.name);
+    s->_name = this->_heapWriter->push_string(encoding->name.name);
     return unique_ptr<binary::TypeEncoding>(s);
 }
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize(typeEncoding::UnionEncoding *encoding) {
     binary::DeclarationReferenceEncoding* s = new binary::DeclarationReferenceEncoding(BinaryTypeEncodingType::UnionDeclarationReference);
-    s->_name = this->_heapWriter.push_string(encoding->name.name);
+    s->_name = this->_heapWriter->push_string(encoding->name.name);
     return unique_ptr<binary::TypeEncoding>(s);
 }
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize(typeEncoding::InterfaceDeclarationEncoding *encoding) {
     binary::InterfaceDeclarationEncoding* s = new binary::InterfaceDeclarationEncoding();
-    s->_name = this->_heapWriter.push_string(encoding->name.name);
+    s->_name = this->_heapWriter->push_string(encoding->name.name);
     return unique_ptr<binary::TypeEncoding>(s);
 }
 
@@ -184,7 +184,7 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::serialize
     s->_fieldsCount = (uint8_t)encoding->fieldNames.size();
 
     for (string& fieldName : encoding->fieldNames) {
-        s->_fieldNames.push_back(this->_heapWriter.push_string(fieldName));
+        s->_fieldNames.push_back(this->_heapWriter->push_string(fieldName));
     }
 
     for (std::unique_ptr<typeEncoding::TypeEncoding>& fieldEncoding : encoding->fieldEncodings) {

--- a/src/merger/src/binary/binaryTypeEncodingSerializer.h
+++ b/src/merger/src/binary/binaryTypeEncodingSerializer.h
@@ -20,12 +20,12 @@ namespace binary {
      */
     class BinaryTypeEncodingSerializer : public utils::TypeEncodingSerializer<unique_ptr<binary::TypeEncoding>> {
     private:
-        BinaryWriter _heapWriter;
+        std::shared_ptr<BinaryWriter> _heapWriter;
 
         unique_ptr<TypeEncoding> serializeRecordEncoding(binary::BinaryTypeEncodingType encodingType, typeEncoding::AnonymousRecordEncoding *encoding);
 
     public:
-        BinaryTypeEncodingSerializer(BinaryWriter& heapWriter) : _heapWriter(heapWriter) { }
+        BinaryTypeEncodingSerializer(std::shared_ptr<BinaryWriter> heapWriter) : _heapWriter(heapWriter) { }
 
         MetaFileOffset serialize(std::vector<typeEncoding::TypeEncoding*>& encodings);
 

--- a/src/merger/src/binary/metaFile.cpp
+++ b/src/merger/src/binary/metaFile.cpp
@@ -14,18 +14,9 @@ binary::MetaFileOffset binary::MetaFile::getFromGlobalTable(const std::string& j
 }
 
 void binary::MetaFile::registerTopLevelModules(std::vector<std::string> &topLevelModules) {
-    binary::BinaryWriter writer = this->heap_writer();
     for (auto& topLevelModule : topLevelModules) {
-        this->_topLevelModulesOffset.push_back(writer.push_string(topLevelModule));
+        this->_topLevelModulesOffset.push_back(this->_heapWriter->push_string(topLevelModule));
     }
-}
-
-binary::BinaryWriter binary::MetaFile::heap_writer() {
-    return binary::BinaryWriter(this->_heap, this->pointer_size, this->array_count_size);
-}
-
-binary::BinaryReader binary::MetaFile::heap_reader() {
-    return binary::BinaryReader(this->_heap, this->pointer_size, this->array_count_size);
 }
 
 void binary::MetaFile::save(string filename) {
@@ -44,8 +35,7 @@ void binary::MetaFile::save(std::shared_ptr<utils::Stream> stream) {
     this->modules_offset = writer.push_binaryArray(this->_topLevelModulesOffset);
 
     // dump global table
-    BinaryWriter heapWriter = this->heap_writer();
-    std::vector<binary::MetaFileOffset> offsets = this->_globalTableSymbols->serialize(heapWriter);
+    std::vector<binary::MetaFileOffset> offsets = this->_globalTableSymbols->serialize(this->_heapWriter.get());
     this->globalTable_offset = writer.push_binaryArray(offsets);
 
     // dump heap

--- a/src/merger/src/binary/metaFile.cpp
+++ b/src/merger/src/binary/metaFile.cpp
@@ -13,6 +13,13 @@ binary::MetaFileOffset binary::MetaFile::getFromGlobalTable(const std::string& j
     return this->_globalTableSymbols->get(jsName);
 }
 
+void binary::MetaFile::registerTopLevelModules(std::vector<std::string> &topLevelModules) {
+    binary::BinaryWriter writer = this->heap_writer();
+    for (auto& topLevelModule : topLevelModules) {
+        this->_topLevelModulesOffset.push_back(writer.push_string(topLevelModule));
+    }
+}
+
 binary::BinaryWriter binary::MetaFile::heap_writer() {
     return binary::BinaryWriter(this->_heap, this->pointer_size, this->array_count_size);
 }
@@ -28,14 +35,30 @@ void binary::MetaFile::save(string filename) {
 }
 
 void binary::MetaFile::save(std::shared_ptr<utils::Stream> stream) {
+    const int HEAD_SECTION_SIZE = 2 + (this->pointer_size * 3);
+    stream->set_position(HEAD_SECTION_SIZE);
+
+    BinaryWriter writer = BinaryWriter(stream, this->pointer_size, this->array_count_size);
+
+    // dump modules table
+    this->modules_offset = writer.push_binaryArray(this->_topLevelModulesOffset);
+
     // dump global table
-    BinaryWriter globalTableStreamWriter = BinaryWriter(stream, this->pointer_size, this->array_count_size);
     BinaryWriter heapWriter = this->heap_writer();
     std::vector<binary::MetaFileOffset> offsets = this->_globalTableSymbols->serialize(heapWriter);
-    globalTableStreamWriter.push_binaryArray(offsets);
+    this->globalTable_offset = writer.push_binaryArray(offsets);
 
     // dump heap
+    this->heap_offset = stream->position();
     for (auto byteIter = this->_heap->begin(); byteIter != this->_heap->end(); ++byteIter) {
         stream->push_byte(*byteIter);
     }
+
+    // Head section
+    stream->set_position(0);
+    writer.push_byte(this->pointer_size);
+    writer.push_byte(this->array_count_size);
+    writer.push_pointer(this->modules_offset);
+    writer.push_pointer(this->globalTable_offset);
+    writer.push_pointer(this->heap_offset);
 }

--- a/src/merger/src/binary/metaFile.h
+++ b/src/merger/src/binary/metaFile.h
@@ -21,14 +21,15 @@ namespace binary {
     class MetaFile {
     private:
         std::unique_ptr<BinaryHashtable> _globalTableSymbols;
+        std::vector<MetaFileOffset> _topLevelModulesOffset;
         std::shared_ptr<utils::MemoryStream> _heap;
 
         // file properties
         int pointer_size = 4;
         int array_count_size = 4;
         MetaFileOffset globalTable_offset = 0;
+        MetaFileOffset modules_offset = 0;
         MetaFileOffset heap_offset = 0;
-        MetaFileOffset _offset = 0;
 
     public:
         /*
@@ -60,6 +61,8 @@ namespace binary {
          * \return The offset in the heap
          */
         MetaFileOffset getFromGlobalTable(const std::string& jsName);
+
+        void registerTopLevelModules(std::vector<std::string>& topLevelModules);
 
         /// heap
         /*

--- a/src/merger/src/binary/metaFile.h
+++ b/src/merger/src/binary/metaFile.h
@@ -23,6 +23,8 @@ namespace binary {
         std::unique_ptr<BinaryHashtable> _globalTableSymbols;
         std::vector<MetaFileOffset> _topLevelModulesOffset;
         std::shared_ptr<utils::MemoryStream> _heap;
+        shared_ptr<BinaryWriter> _heapWriter;
+        shared_ptr<BinaryReader> _heapReader;
 
         // file properties
         int pointer_size = 4;
@@ -40,6 +42,9 @@ namespace binary {
             this->_globalTableSymbols = std::unique_ptr<BinaryHashtable>(new BinaryHashtable(size));
             this->_heap = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
             this->_heap->push_byte(0); // mark heap
+
+            this->_heapReader = unique_ptr<binary::BinaryReader>(new binary::BinaryReader(this->_heap, this->pointer_size, this->array_count_size));
+            this->_heapWriter = unique_ptr<binary::BinaryWriter>(new binary::BinaryWriter(this->_heap, this->pointer_size, this->array_count_size));
         }
         MetaFile() : MetaFile(10) { }
 
@@ -68,11 +73,15 @@ namespace binary {
         /*
          * \brief Creates a \c BinaryWriter for this file heap
          */
-        BinaryWriter heap_writer();
+        shared_ptr<BinaryWriter> heap_writer() {
+            return this->_heapWriter;
+        }
         /*
          * \brief Creates a \c BinaryReader for this file heap
          */
-        BinaryReader heap_reader();
+        shared_ptr<BinaryReader> heap_reader() {
+            return this->_heapReader;
+        }
 
         /// I/O
         /*

--- a/src/merger/test/binaryHashtableTests.cpp
+++ b/src/merger/test/binaryHashtableTests.cpp
@@ -30,7 +30,7 @@ TEST (BinaryHashTableTests, TestSerialization_SizeShouldMatch) {
     std::shared_ptr<utils::MemoryStream> stream = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     binary::BinaryWriter writer = binary::BinaryWriter(stream, 4, 4);
 
-    std::vector<binary::MetaFileOffset> globalTable = target.serialize(writer);
+    std::vector<binary::MetaFileOffset> globalTable = target.serialize(&writer);
     EXPECT_EQ(target.size(), globalTable.size());
 }
 
@@ -63,7 +63,7 @@ TEST (BinaryHashTableTests, TestSerialization_ArraysInHeap_2_1) {
     std::shared_ptr<utils::MemoryStream> stream = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     binary::BinaryWriter writer = binary::BinaryWriter(stream, pointer_size, array_count_size);
 
-    target.serialize(writer);
+    target.serialize(&writer);
 
     /*
     Used slots:
@@ -94,7 +94,7 @@ TEST (BinaryHashTableTests, TestSerialization_ArraysInHeap_8_4) {
     std::shared_ptr<utils::MemoryStream> stream = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     binary::BinaryWriter writer = binary::BinaryWriter(stream, pointer_size, array_count_size);
 
-    target.serialize(writer);
+    target.serialize(&writer);
 
     /*
     Used slots:
@@ -125,7 +125,7 @@ TEST (BinaryHashTableTests, TestSerialization_Offsets) {
     std::shared_ptr<utils::MemoryStream> stream = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     binary::BinaryWriter writer = binary::BinaryWriter(stream, pointer_size, array_count_size);
 
-    std::vector<binary::MetaFileOffset> offsets = target.serialize(writer);
+    std::vector<binary::MetaFileOffset> offsets = target.serialize(&writer);
 
     /*
     Used slots:

--- a/src/merger/test/binarySerializerTests.cpp
+++ b/src/merger/test/binarySerializerTests.cpp
@@ -64,31 +64,30 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_FunctionMeta) {
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
 
     // Type encoding
-    int encodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->signature.size(), reader.read_arrayCount());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Void, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
+    int encodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->signature.size(), reader->read_arrayCount());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Void, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
 
     // FunctionMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    EXPECT_EQ(target->flags | meta::SymbolType::Function, reader.read_byte());
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(encodingOffset, reader.read_pointer());
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    EXPECT_EQ(target->flags | meta::SymbolType::Function, reader->read_byte());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(encodingOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_FunctionMetaWithDifferentNames) {
@@ -111,39 +110,38 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_FunctionMetaWithDif
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int jsNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->jsName, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int jsNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->jsName, reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
 
-    int nameOffsetBA = reader.baseStream()->position();
-    EXPECT_EQ(jsNameOffset, reader.read_pointer());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
+    int nameOffsetBA = reader->baseStream()->position();
+    EXPECT_EQ(jsNameOffset, reader->read_pointer());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
 
     // Type encoding
-    int encodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->signature.size(), reader.read_arrayCount());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Void, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
+    int encodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->signature.size(), reader->read_arrayCount());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Void, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
 
     // FunctionMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffsetBA, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffsetBA, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::MetaFlags::HasName | meta::SymbolType::Function, flags);
     EXPECT_EQ(meta::SymbolType::Function, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(encodingOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(encodingOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_StructMeta) {
@@ -166,49 +164,48 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_StructMeta) {
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
 
     // field names
-    int a1Offset = reader.baseStream()->position();
-    EXPECT_EQ(target->fields.at(0).name, reader.read_string());
-    int b1Offset = reader.baseStream()->position();
-    EXPECT_EQ(target->fields.at(1).name, reader.read_string());
-    int c1Offset = reader.baseStream()->position();
-    EXPECT_EQ(target->fields.at(2).name, reader.read_string());
+    int a1Offset = reader->baseStream()->position();
+    EXPECT_EQ(target->fields.at(0).name, reader->read_string());
+    int b1Offset = reader->baseStream()->position();
+    EXPECT_EQ(target->fields.at(1).name, reader->read_string());
+    int c1Offset = reader->baseStream()->position();
+    EXPECT_EQ(target->fields.at(2).name, reader->read_string());
 
     // field names binary array
-    int fieldNamesOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->fields.size(), reader.read_arrayCount());
-    EXPECT_EQ(a1Offset, reader.read_pointer()); // a1
-    EXPECT_EQ(b1Offset, reader.read_pointer()); // b1
-    EXPECT_EQ(c1Offset, reader.read_pointer()); // c1
+    int fieldNamesOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->fields.size(), reader->read_arrayCount());
+    EXPECT_EQ(a1Offset, reader->read_pointer()); // a1
+    EXPECT_EQ(b1Offset, reader->read_pointer()); // b1
+    EXPECT_EQ(c1Offset, reader->read_pointer()); // c1
 
     // field encodings
-    int encodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->fields.size(), reader.read_arrayCount());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Double, reader.read_byte());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Long, reader.read_byte());
+    int encodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->fields.size(), reader->read_arrayCount());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Double, reader->read_byte());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Long, reader->read_byte());
 
     // RecordMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::SymbolType::Struct, flags);
     EXPECT_EQ(meta::SymbolType::Struct, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(fieldNamesOffset, reader.read_pointer());
-    EXPECT_EQ(encodingOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(fieldNamesOffset, reader->read_pointer());
+    EXPECT_EQ(encodingOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_VarMeta) {
@@ -229,30 +226,29 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_VarMeta) {
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
 
     // Type encoding
-    int encodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
+    int encodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
 
     // VarMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::SymbolType::Var, flags);
     EXPECT_EQ(meta::SymbolType::Var, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(encodingOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(encodingOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_JSCodeMeta) {
@@ -273,28 +269,27 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_JSCodeMeta) {
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
-    int encodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->jsCode, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
+    int encodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->jsCode, reader->read_string());
 
     // JsCodeMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::SymbolType::JsCode, flags);
     EXPECT_EQ(meta::SymbolType::JsCode, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(encodingOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(encodingOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_Interface) {
@@ -330,72 +325,71 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_Interface) {
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
-    int methodSelectorOffset = reader.baseStream()->position();
-    EXPECT_EQ(method1->selector, reader.read_string());
-    int methodSignatureOffset = reader.baseStream()->position();
-    EXPECT_EQ(method1->signature.size(), reader.read_arrayCount());
-    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader.read_byte());
-    int methodTypeEncodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(method1->typeEncoding, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
+    int methodSelectorOffset = reader->baseStream()->position();
+    EXPECT_EQ(method1->selector, reader->read_string());
+    int methodSignatureOffset = reader->baseStream()->position();
+    EXPECT_EQ(method1->signature.size(), reader->read_arrayCount());
+    EXPECT_EQ(binary::BinaryTypeEncodingType::Int, reader->read_byte());
+    int methodTypeEncodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(method1->typeEncoding, reader->read_string());
 
     // MethodMeta
-    int methodOffset = reader.baseStream()->position();
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    EXPECT_EQ(method1->flags, reader.read_byte());
-    EXPECT_EQ(0, reader.read_short()); // module id
-    EXPECT_EQ(0, reader.read_byte()); // introduced in
-    EXPECT_EQ(methodSelectorOffset, reader.read_pointer()); // selector
-    EXPECT_EQ(methodSignatureOffset, reader.read_pointer()); // encoding
-    EXPECT_EQ(methodTypeEncodingOffset, reader.read_pointer()); // compiler encoding
+    int methodOffset = reader->baseStream()->position();
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    EXPECT_EQ(method1->flags, reader->read_byte());
+    EXPECT_EQ(0, reader->read_short()); // module id
+    EXPECT_EQ(0, reader->read_byte()); // introduced in
+    EXPECT_EQ(methodSelectorOffset, reader->read_pointer()); // selector
+    EXPECT_EQ(methodSignatureOffset, reader->read_pointer()); // encoding
+    EXPECT_EQ(methodTypeEncodingOffset, reader->read_pointer()); // compiler encoding
 
     // PropertyMeta
-    int propertyOffset = reader.baseStream()->position();
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    EXPECT_EQ(property1.flags, reader.read_byte());
-    EXPECT_EQ(0, reader.read_short()); // module id
-    EXPECT_EQ(0, reader.read_byte()); // introduced in
-    EXPECT_EQ(methodOffset, reader.read_pointer());
+    int propertyOffset = reader->baseStream()->position();
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    EXPECT_EQ(property1.flags, reader->read_byte());
+    EXPECT_EQ(0, reader->read_short()); // module id
+    EXPECT_EQ(0, reader->read_byte()); // introduced in
+    EXPECT_EQ(methodOffset, reader->read_pointer());
 
-    int propertyListOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->properties.size(), reader.read_arrayCount());
-    EXPECT_EQ(propertyOffset, reader.read_pointer());
+    int propertyListOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->properties.size(), reader->read_arrayCount());
+    EXPECT_EQ(propertyOffset, reader->read_pointer());
 
     // protocols
-    int protocolNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->protocols[0].name, reader.read_string());
+    int protocolNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->protocols[0].name, reader->read_string());
 
-    int protocolListOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->protocols.size(), reader.read_arrayCount());
-    EXPECT_EQ(protocolNameOffset, reader.read_pointer());
+    int protocolListOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->protocols.size(), reader->read_arrayCount());
+    EXPECT_EQ(protocolNameOffset, reader->read_pointer());
 
     // base name
-    int baseNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->baseName.name, reader.read_string());
+    int baseNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->baseName.name, reader->read_string());
 
     // InterfaceMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::SymbolType::Interface, flags);
     EXPECT_EQ(meta::SymbolType::Interface, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(0, reader.read_pointer());
-    EXPECT_EQ(0, reader.read_pointer());
-    EXPECT_EQ(propertyListOffset, reader.read_pointer());
-    EXPECT_EQ(protocolListOffset, reader.read_pointer());
-    EXPECT_EQ(-1, reader.read_short());
-    EXPECT_EQ(baseNameOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(0, reader->read_pointer());
+    EXPECT_EQ(0, reader->read_pointer());
+    EXPECT_EQ(propertyListOffset, reader->read_pointer());
+    EXPECT_EQ(protocolListOffset, reader->read_pointer());
+    EXPECT_EQ(-1, reader->read_short());
+    EXPECT_EQ(baseNameOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }
 
 TEST (BinarySerializer_SerializationTests, TestSerialization_InterfaceWithConstructor) {
@@ -424,59 +418,58 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_InterfaceWithConstr
 
     /// Check heap
 
-    binary::BinaryReader reader = file->heap_reader();
-    reader.baseStream()->set_position(0);
-    EXPECT_EQ(0, reader.read_byte()); // marking byte
-    EXPECT_EQ("Foundation", reader.read_string());
-    int moduleOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->module, reader.read_string());
-    int nameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->name, reader.read_string());
-    int methodNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(method1.name, reader.read_string());
-    int methodTypeEncodingOffset = reader.baseStream()->position();
-    EXPECT_EQ(method1.typeEncoding, reader.read_string());
+    std::shared_ptr<binary::BinaryReader> reader = file->heap_reader();
+    reader->baseStream()->set_position(0);
+    EXPECT_EQ(0, reader->read_byte()); // marking byte
+    int moduleOffset = reader->baseStream()->position();
+    EXPECT_EQ("Foundation", reader->read_string());
+    int nameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->name, reader->read_string());
+    int methodNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(method1.name, reader->read_string());
+    int methodTypeEncodingOffset = reader->baseStream()->position();
+    EXPECT_EQ(method1.typeEncoding, reader->read_string());
 
     // MethodMeta
-    int methodOffset = reader.baseStream()->position();
-    EXPECT_EQ(methodNameOffset, reader.read_pointer());
-    EXPECT_EQ(method1.flags, reader.read_byte());
-    EXPECT_EQ(0, reader.read_short()); // module id
-    EXPECT_EQ(0, reader.read_byte()); // introduced in
-    EXPECT_EQ(methodNameOffset, reader.read_pointer()); // selector
-    EXPECT_EQ(0, reader.read_pointer()); // encoding
-    EXPECT_EQ(methodTypeEncodingOffset, reader.read_pointer()); // compiler encoding
+    int methodOffset = reader->baseStream()->position();
+    EXPECT_EQ(methodNameOffset, reader->read_pointer());
+    EXPECT_EQ(method1.flags, reader->read_byte());
+    EXPECT_EQ(0, reader->read_short()); // module id
+    EXPECT_EQ(0, reader->read_byte()); // introduced in
+    EXPECT_EQ(methodNameOffset, reader->read_pointer()); // selector
+    EXPECT_EQ(0, reader->read_pointer()); // encoding
+    EXPECT_EQ(methodTypeEncodingOffset, reader->read_pointer()); // compiler encoding
 
-    int methodListOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->instanceMethods.size(), reader.read_arrayCount());
-    EXPECT_EQ(methodOffset, reader.read_pointer());
+    int methodListOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->instanceMethods.size(), reader->read_arrayCount());
+    EXPECT_EQ(methodOffset, reader->read_pointer());
 
     // protocols
-    int protocolNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->protocols[0].name, reader.read_string());
+    int protocolNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->protocols[0].name, reader->read_string());
 
-    int protocolListOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->protocols.size(), reader.read_arrayCount());
-    EXPECT_EQ(protocolNameOffset, reader.read_pointer());
+    int protocolListOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->protocols.size(), reader->read_arrayCount());
+    EXPECT_EQ(protocolNameOffset, reader->read_pointer());
 
     // base name
-    int baseNameOffset = reader.baseStream()->position();
-    EXPECT_EQ(target->baseName.name, reader.read_string());
+    int baseNameOffset = reader->baseStream()->position();
+    EXPECT_EQ(target->baseName.name, reader->read_string());
 
     // InterfaceMeta
-    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader.baseStream()->position());
-    EXPECT_EQ(nameOffset, reader.read_pointer());
-    uint8_t flags = reader.read_byte();
+    EXPECT_EQ(file->getFromGlobalTable(target->jsName), reader->baseStream()->position());
+    EXPECT_EQ(nameOffset, reader->read_pointer());
+    uint8_t flags = reader->read_byte();
     EXPECT_EQ(target->flags | meta::SymbolType::Interface, flags);
     EXPECT_EQ(meta::SymbolType::Interface, flags & 7);
-    EXPECT_EQ(moduleOffset, reader.read_short());
-    EXPECT_EQ(2 << 3, reader.read_byte());
-    EXPECT_EQ(methodListOffset, reader.read_pointer());
-    EXPECT_EQ(0, reader.read_pointer());
-    EXPECT_EQ(0, reader.read_pointer());
-    EXPECT_EQ(protocolListOffset, reader.read_pointer());
-    EXPECT_EQ(0, reader.read_short());
-    EXPECT_EQ(baseNameOffset, reader.read_pointer());
+    EXPECT_EQ(moduleOffset, reader->read_short());
+    EXPECT_EQ(2 << 3, reader->read_byte());
+    EXPECT_EQ(methodListOffset, reader->read_pointer());
+    EXPECT_EQ(0, reader->read_pointer());
+    EXPECT_EQ(0, reader->read_pointer());
+    EXPECT_EQ(protocolListOffset, reader->read_pointer());
+    EXPECT_EQ(0, reader->read_short());
+    EXPECT_EQ(baseNameOffset, reader->read_pointer());
 
-    EXPECT_EQ(reader.baseStream()->size(), reader.baseStream()->position());
+    EXPECT_EQ(reader->baseStream()->size(), reader->baseStream()->position());
 }

--- a/src/merger/test/binarySerializerTests.cpp
+++ b/src/merger/test/binarySerializerTests.cpp
@@ -67,6 +67,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_FunctionMeta) {
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();
@@ -113,6 +114,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_FunctionMetaWithDif
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int jsNameOffset = reader.baseStream()->position();
@@ -167,6 +169,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_StructMeta) {
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();
@@ -229,6 +232,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_VarMeta) {
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();
@@ -272,6 +276,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_JSCodeMeta) {
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();
@@ -328,6 +333,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_Interface) {
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();
@@ -421,6 +427,7 @@ TEST (BinarySerializer_SerializationTests, TestSerialization_InterfaceWithConstr
     binary::BinaryReader reader = file->heap_reader();
     reader.baseStream()->set_position(0);
     EXPECT_EQ(0, reader.read_byte()); // marking byte
+    EXPECT_EQ("Foundation", reader.read_string());
     int moduleOffset = reader.baseStream()->position();
     EXPECT_EQ(target->module, reader.read_string());
     int nameOffset = reader.baseStream()->position();

--- a/src/merger/test/binaryStructuresTests.cpp
+++ b/src/merger/test/binaryStructuresTests.cpp
@@ -9,7 +9,7 @@ TEST(BinaryStructuresTests, TestSave1TypeEncoding) {
     binary::BinaryWriter writer(ms, 4, 4);
 
     binary::TypeEncoding target(binary::BinaryTypeEncodingType::Int);
-    target.save(writer);
+    target.save(&writer);
 
     EXPECT_EQ(1, ms->size());
 }
@@ -19,10 +19,10 @@ TEST(BinaryStructuresTests, TestSave2TypeEncodings) {
     binary::BinaryWriter writer(ms, 4, 4);
 
     binary::TypeEncoding target(binary::BinaryTypeEncodingType::Int);
-    target.save(writer);
+    target.save(&writer);
 
     binary::TypeEncoding target2(binary::BinaryTypeEncodingType::LongLong);
-    target2.save(writer);
+    target2.save(&writer);
 
     EXPECT_EQ(2, ms->size());
 }
@@ -35,7 +35,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_IncompleteArray) {
     binary::PointerEncoding* p = new binary::PointerEncoding();
     p->_target = std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Void));
     target._elementType = std::unique_ptr<binary::TypeEncoding>(p);
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(0, offset);
     EXPECT_EQ(3, ms->size());
@@ -56,7 +56,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_ConstantArrayEncoding) {
     p->_target = std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Void));
     target._elementType = std::unique_ptr<binary::TypeEncoding>(p);
     target._size = 20;
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(0, offset);
     EXPECT_EQ(7, ms->size());
@@ -77,7 +77,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_DeclarationReferenceEncoding) 
     binary::DeclarationReferenceEncoding target(binary::BinaryTypeEncodingType::StructDeclarationReference);
     std::string testStr = "Hello";
     target._name = writer.push_string(testStr);
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(testStr.size() + 1, offset);
     EXPECT_EQ(offset + pointerSize + 1, ms->size());
@@ -98,7 +98,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_InterfaceDeclarationEncoding) 
     binary::InterfaceDeclarationEncoding target;
     std::string testStr = "NSArray";
     target._name = writer.push_string(testStr);
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(testStr.size() + 1, offset);
     EXPECT_EQ(offset + pointerSize + 1, ms->size());
@@ -117,7 +117,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_PointerEncoding) {
 
     binary::PointerEncoding target;
     target._target = std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Void));
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(0, offset);
     EXPECT_EQ(2, ms->size());
@@ -138,7 +138,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_BlockEncoding) {
     target._encodings.push_back(std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Int)));
     target._encodings.push_back(std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Double)));
 
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(0, offset);
     EXPECT_EQ(5, ms->size());
@@ -166,7 +166,7 @@ TEST(BinaryStructuresTests, TestSave_TypeEncoding_AnonymousRecordEncoding) {
     target._fieldEncodings.push_back(std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Int)));
     target._fieldEncodings.push_back(std::unique_ptr<binary::TypeEncoding>(new binary::TypeEncoding(binary::BinaryTypeEncodingType::Double)));
 
-    binary::MetaFileOffset offset = target.save(writer);
+    binary::MetaFileOffset offset = target.save(&writer);
 
     EXPECT_EQ(9, offset);
     EXPECT_EQ(26, ms->size());

--- a/src/merger/test/binaryTypeEncodingSerializerTests.cpp
+++ b/src/merger/test/binaryTypeEncodingSerializerTests.cpp
@@ -6,7 +6,7 @@
 
 TEST(BinaryTypeEncodingSerializerTests, TestUnknown) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UnknownEncoding target;
 
@@ -17,7 +17,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUnknown) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestVoidEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::VoidEncoding target;
 
@@ -28,7 +28,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestVoidEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestBoolEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::BoolEncoding target;
 
@@ -39,7 +39,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestBoolEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestShortEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ShortEncoding target;
 
@@ -50,7 +50,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestShortEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestUShortEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UShortEncoding target;
 
@@ -61,7 +61,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUShortEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestIntEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::IntEncoding target;
 
@@ -72,7 +72,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestIntEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestUIntEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UIntEncoding target;
 
@@ -83,7 +83,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUIntEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestLongEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::LongEncoding target;
 
@@ -94,7 +94,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestLongEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestULongEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ULongEncoding target;
 
@@ -105,7 +105,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestULongEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestLongLongEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::LongLongEncoding target;
 
@@ -116,7 +116,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestLongLongEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestULongLongEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ULongLongEncoding target;
 
@@ -127,7 +127,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestULongLongEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestSignedCharEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::SignedCharEncoding target;
 
@@ -138,7 +138,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestSignedCharEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestUnsignedCharEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UnsignedCharEncoding target;
 
@@ -149,7 +149,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUnsignedCharEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestUnicharEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UnicharEncoding target;
 
@@ -160,7 +160,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUnicharEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestCStringEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::CStringEncoding target;
 
@@ -171,7 +171,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestCStringEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestFloatEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::FloatEncoding target;
 
@@ -182,7 +182,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestFloatEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestDoubleEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::DoubleEncoding target;
 
@@ -193,7 +193,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestDoubleEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestVaListEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::VaListEncoding target;
 
@@ -204,7 +204,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestVaListEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestSelectorEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::SelectorEncoding target;
 
@@ -215,7 +215,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestSelectorEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestInstancetypeEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::InstancetypeEncoding target;
 
@@ -226,7 +226,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestInstancetypeEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestClassEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ClassEncoding target;
 
@@ -237,7 +237,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestClassEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestProtocolEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ProtocolEncoding target;
 
@@ -248,7 +248,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestProtocolEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestIdEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::IdEncoding target;
     target.protocols.push_back({ .name = "Test", .module = "TestModule" });
@@ -260,7 +260,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestIdEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestConstantArrayEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::ConstantArrayEncoding target;
     target.elementType = std::unique_ptr<typeEncoding::TypeEncoding>(new typeEncoding::IntEncoding());
@@ -276,7 +276,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestConstantArrayEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestIncompleteArrayEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::IncompleteArrayEncoding target;
     target.elementType = std::unique_ptr<typeEncoding::TypeEncoding>(new typeEncoding::IntEncoding());
@@ -291,7 +291,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestIncompleteArrayEncoding) {
 TEST(BinaryTypeEncodingSerializerTests, TestInterfaceEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     ms->push_byte(0x10); // change the memory stream
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::InterfaceEncoding target;
     target.name = { .name = "Test", .module = "TestModule" };
@@ -305,7 +305,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestInterfaceEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestPointerEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::PointerEncoding target;
     target.target = std::unique_ptr<typeEncoding::TypeEncoding>(new typeEncoding::VoidEncoding());
@@ -319,7 +319,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestPointerEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestBlockEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::BlockEncoding target;
     target.blockCall.push_back(std::unique_ptr<typeEncoding::TypeEncoding>(new typeEncoding::VoidEncoding()));
@@ -338,7 +338,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestBlockEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestFunctionEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::FunctionEncoding target;
     target.functionCall.push_back(std::unique_ptr<typeEncoding::TypeEncoding>(new typeEncoding::VoidEncoding()));
@@ -358,7 +358,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestFunctionEncoding) {
 TEST(BinaryTypeEncodingSerializerTests, TestStructEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     ms->push_byte(0x10); // change the memory stream
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::StructEncoding target;
     target.name = { .name = "Test", .module = "TestModule" };
@@ -373,7 +373,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestStructEncoding) {
 TEST(BinaryTypeEncodingSerializerTests, TestUnionEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     ms->push_byte(0x10); // change the memory stream
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::UnionEncoding target;
     target.name = { .name = "Test", .module = "TestModule" };
@@ -388,7 +388,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestUnionEncoding) {
 TEST(BinaryTypeEncodingSerializerTests, TestInterfaceDeclarationEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
     ms->push_byte(0x10); // change the memory stream
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::InterfaceDeclarationEncoding target;
     target.name = { .name = "Test", .module = "TestModule" };
@@ -402,7 +402,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestInterfaceDeclarationEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestAnonymousStructEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::AnonymousStructEncoding target;
     target.fieldNames.push_back("x1");
@@ -423,7 +423,7 @@ TEST(BinaryTypeEncodingSerializerTests, TestAnonymousStructEncoding) {
 
 TEST(BinaryTypeEncodingSerializerTests, TestAnonymousUnionEncoding) {
     std::shared_ptr<utils::MemoryStream> ms = std::shared_ptr<utils::MemoryStream>(new utils::MemoryStream());
-    binary::BinaryWriter writer(ms, 4, 4);
+    std::shared_ptr<binary::BinaryWriter> writer = std::shared_ptr<binary::BinaryWriter>(new binary::BinaryWriter(ms, 4, 4));
     binary::BinaryTypeEncodingSerializer s(writer);
     typeEncoding::AnonymousUnionEncoding target;
     target.fieldNames.push_back("x1");


### PR DESCRIPTION
Changes in metadata generator:
- fix for heap reader and writer so that only a single instance is maintained
- removed submodule information from binary file
