### PR TITLE
[TypeScript] Declare index accessors and iterator methods

### DIFF
--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -453,7 +453,8 @@ std::string DefinitionWriter::tsifyType(const Type& type)
     case TypeFunctionPointer:
         return "interop.FunctionReference<" + writeFunctionProto(type.getDetailsAs<FunctionPointerTypeDetails>().signature)
                + ">";
-    case TypeInterface: {
+    case TypeInterface:
+    case TypeBridgedInterface: {
         InterfaceTypeDetails& details = type.getDetailsAs<InterfaceTypeDetails>();
         if (details.id.jsName == "NSNumber") {
             return "number";

--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -113,6 +113,14 @@ void DefinitionWriter::visit(InterfaceMeta* meta)
         }
     }
 
+    if (compoundInstanceMethods.find("objectAtIndexedSubscript") != compoundInstanceMethods.end()) {
+        _buffer << "\t\t[index: number]: any;" << std::endl;
+    }
+
+    if (compoundInstanceMethods.find("countByEnumeratingWithStateObjectsCount") != compoundInstanceMethods.end()) {
+        _buffer << "\t\t[Symbol.iterator](): Iterator<any>;" << std::endl;
+    }
+
     for (auto& methodPair : compoundInstanceMethods) {
         if (compoundProperties.find(methodPair.first) != compoundProperties.end()) {
             continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@ public:
 
         // Serialize Meta objects to Yaml
         if (!cla_outputYamlFolder.empty()) {
+            llvm::sys::fs::create_directories(cla_outputYamlFolder);
             for (Meta::MetaContainer::top_level_modules_iterator it = metaContainer.top_level_modules_begin(); it != metaContainer.top_level_modules_end(); ++it) {
                 Yaml::YamlSerializer::serialize<Meta::ModuleMeta>(std::string(cla_outputYamlFolder.getValue()) + "/" + it->getFullName() + ".yaml", *it);
             }


### PR DESCRIPTION
The runtime bridges `objectAtIndexedSubscript:` to indexed gets and `countByEnumeratingWithState:objects:count:` to `Symbol.iterator` iterables. This patch reflects the current reality in the TypeScript definitions.
