### PR TITLE
Remove JsCodeMeta from meta hierarchy.

### DIFF
--- a/src/Binary/binarySerializer.h
+++ b/src/Binary/binarySerializer.h
@@ -56,8 +56,14 @@ public:
 
     virtual void visit(::Meta::UnionMeta* Meta) override;
 
-    virtual void visit(::Meta::JsCodeMeta* Meta) override;
+    virtual void visit(::Meta::EnumMeta* Meta) override;
 
     virtual void visit(::Meta::VarMeta* Meta) override;
+
+    virtual void visit(::Meta::EnumConstantMeta* Meta) override;
+
+    virtual void visit(::Meta::PropertyMeta* Meta) override;
+
+    virtual void visit(::Meta::MethodMeta* Meta) override;
 };
 }

--- a/src/Binary/binaryTypeEncodingSerializer.cpp
+++ b/src/Binary/binaryTypeEncodingSerializer.cpp
@@ -119,7 +119,7 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitClas
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitProtocol()
 {
-    return llvm::make_unique<binary::TypeEncoding>(binary::BinaryTypeEncodingType::Protocol);
+    return llvm::make_unique<binary::TypeEncoding>(binary::BinaryTypeEncodingType::ProtocolType);
 }
 
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitId(const ::Meta::IdType& type)

--- a/src/Meta/Filters/ResolveGlobalNamesCollisionsFilter.cpp
+++ b/src/Meta/Filters/ResolveGlobalNamesCollisionsFilter.cpp
@@ -10,18 +10,20 @@ static int getPriority(Meta* meta)
 {
     switch (meta->type) {
     case MetaType::Interface:
-        return 7;
+        return 8;
     case MetaType::Protocol:
-        return 6;
+        return 7;
     case MetaType::Function:
-        return 5;
+        return 6;
     case MetaType::Var:
-        return 4;
+        return 5;
     case MetaType::Struct:
-        return 3;
+        return 4;
     case MetaType::Union:
+        return 3;
+    case MetaType::Enum:
         return 2;
-    case MetaType::JsCode:
+    case MetaType::EnumConstant:
         return 1;
     default:
         return 0;
@@ -44,8 +46,10 @@ static std::string renameMeta(MetaType type, std::string& originalJsName, int in
         return originalJsName + "Struct" + indexStr;
     case MetaType::Union:
         return originalJsName + "Union" + indexStr;
-    case MetaType::JsCode:
-        return originalJsName + "Decl" + indexStr;
+    case MetaType::Enum:
+        return originalJsName + "Enum" + indexStr;
+    case MetaType::EnumConstant:
+        return originalJsName + "Var" + indexStr;
     default:
         return originalJsName + "Decl" + indexStr;
     }

--- a/src/Meta/MetaEntities.cpp
+++ b/src/Meta/MetaEntities.cpp
@@ -1,26 +1,51 @@
 #include "MetaEntities.h"
 
+static void visitBaseClass(Meta::MetaVisitor* visitor, Meta::BaseClassMeta* baseClass)
+{
+    for (Meta::MethodMeta* method : baseClass->staticMethods) {
+        method->visit(visitor);
+    }
+
+    for (Meta::MethodMeta* method : baseClass->instanceMethods) {
+        method->visit(visitor);
+    }
+
+    for (Meta::PropertyMeta* property : baseClass->properties) {
+        property->visit(visitor);
+    }
+}
+
 void Meta::MethodMeta::visit(MetaVisitor* visitor)
 {
+    visitor->visit(this);
 }
 
 void Meta::PropertyMeta::visit(MetaVisitor* visitor)
 {
+    visitor->visit(this);
+}
+
+void Meta::EnumConstantMeta::visit(MetaVisitor* visitor)
+{
+    visitor->visit(this);
 }
 
 void Meta::CategoryMeta::visit(MetaVisitor* visitor)
 {
     visitor->visit(this);
+    visitBaseClass(visitor, this);
 }
 
 void Meta::InterfaceMeta::visit(MetaVisitor* visitor)
 {
     visitor->visit(this);
+    visitBaseClass(visitor, this);
 }
 
 void Meta::ProtocolMeta::visit(MetaVisitor* visitor)
 {
     visitor->visit(this);
+    visitBaseClass(visitor, this);
 }
 
 void Meta::StructMeta::visit(MetaVisitor* visitor)
@@ -38,7 +63,7 @@ void Meta::FunctionMeta::visit(MetaVisitor* visitor)
     visitor->visit(this);
 }
 
-void Meta::JsCodeMeta::visit(MetaVisitor* visitor)
+void Meta::EnumMeta::visit(MetaVisitor* visitor)
 {
     visitor->visit(this);
 }

--- a/src/Meta/MetaEntities.h
+++ b/src/Meta/MetaEntities.h
@@ -44,13 +44,14 @@ enum MetaType {
     Struct,
     Union,
     Function,
-    JsCode,
+    Enum,
     Var,
     Interface,
     Protocol,
     Category,
     Method,
-    Property
+    Property,
+    EnumConstant
 };
 
 class Meta {
@@ -219,13 +220,33 @@ public:
     virtual void visit(MetaVisitor* visitor) override;
 };
 
-class JsCodeMeta : public Meta {
+class EnumConstantMeta : public Meta {
 public:
-    JsCodeMeta()
+    EnumConstantMeta()
     {
-        this->type = MetaType::JsCode;
+        this->type = MetaType::EnumConstant;
     }
-    std::string jsCode;
+
+    std::string value;
+
+    virtual void visit(MetaVisitor* visitor) override;
+};
+
+struct EnumField {
+    std::string name;
+    std::string value;
+};
+
+class EnumMeta : public Meta {
+public:
+    EnumMeta()
+    {
+        this->type = MetaType::Enum;
+    }
+
+    std::vector<EnumField> fullNameFields;
+
+    std::vector<EnumField> swiftNameFields;
 
     virtual void visit(MetaVisitor* visitor) override;
 };

--- a/src/Meta/MetaFactory.h
+++ b/src/Meta/MetaFactory.h
@@ -34,9 +34,9 @@ private:
 
     void createFromVar(const clang::VarDecl& var, VarMeta& varMeta);
 
-    void createFromEnum(const clang::EnumDecl& enumeration, JsCodeMeta& jsCodeMeta);
+    void createFromEnum(const clang::EnumDecl& enumeration, EnumMeta& enumMeta);
 
-    void createFromEnumConstant(const clang::EnumConstantDecl& enumConstant, JsCodeMeta& jsCodeMeta);
+    void createFromEnumConstant(const clang::EnumConstantDecl& enumConstant, EnumConstantMeta& enumMeta);
 
     void createFromInterface(const clang::ObjCInterfaceDecl& interface, InterfaceMeta& interfaceMeta);
 

--- a/src/Meta/MetaVisitor.h
+++ b/src/Meta/MetaVisitor.h
@@ -8,8 +8,11 @@ class CategoryMeta;
 class FunctionMeta;
 class StructMeta;
 class UnionMeta;
-class JsCodeMeta;
+class EnumMeta;
 class VarMeta;
+class MethodMeta;
+class PropertyMeta;
+class EnumConstantMeta;
 
 class MetaVisitor {
 public:
@@ -25,8 +28,14 @@ public:
 
     virtual void visit(UnionMeta* meta) = 0;
 
-    virtual void visit(JsCodeMeta* meta) = 0;
+    virtual void visit(EnumMeta* meta) = 0;
 
     virtual void visit(VarMeta* meta) = 0;
+
+    virtual void visit(MethodMeta* meta) = 0;
+
+    virtual void visit(PropertyMeta* meta) = 0;
+
+    virtual void visit(EnumConstantMeta* meta) = 0;
 };
 }

--- a/src/Meta/TypeEntities.h
+++ b/src/Meta/TypeEntities.h
@@ -10,7 +10,7 @@ class ProtocolMeta;
 class InterfaceMeta;
 class StructMeta;
 class UnionMeta;
-class JsCodeMeta;
+class EnumMeta;
 
 enum TypeType {
     TypeVoid,
@@ -330,7 +330,7 @@ public:
 
 class EnumType : public Type {
 public:
-    EnumType(Type* underlyingType, JsCodeMeta* enumMeta)
+    EnumType(Type* underlyingType, EnumMeta* enumMeta)
         : Type(TypeType::TypeEnum)
         , underlyingType(underlyingType)
         , enumMeta(enumMeta)
@@ -338,6 +338,6 @@ public:
     }
 
     Type* underlyingType;
-    JsCodeMeta* enumMeta;
+    EnumMeta* enumMeta;
 };
 }

--- a/src/Meta/TypeFactory.cpp
+++ b/src/Meta/TypeFactory.cpp
@@ -377,7 +377,9 @@ shared_ptr<Type> TypeFactory::createFromPointerType(const clang::PointerType* ty
 
 shared_ptr<Type> TypeFactory::createFromEnumType(const clang::EnumType* type)
 {
-    return this->create(type->getDecl()->getIntegerType());
+    Type* innerType = this->create(type->getDecl()->getIntegerType()).get();
+    EnumMeta* enumMeta = &this->_metaFactory->create(*type->getDecl()->getDefinition())->as<EnumMeta>();
+    return make_shared<EnumType>(innerType, enumMeta);
 }
 
 shared_ptr<Type> TypeFactory::createFromRecordType(const clang::RecordType* type)

--- a/src/TypeScript/DefinitionWriter.h
+++ b/src/TypeScript/DefinitionWriter.h
@@ -27,9 +27,15 @@ public:
 
     virtual void visit(Meta::UnionMeta* meta) override;
 
-    virtual void visit(Meta::JsCodeMeta* meta) override;
+    virtual void visit(Meta::EnumMeta* meta) override;
 
     virtual void visit(Meta::VarMeta* meta) override;
+
+    virtual void visit(Meta::MethodMeta* meta) override;
+
+    virtual void visit(Meta::PropertyMeta* meta) override;
+
+    virtual void visit(Meta::EnumConstantMeta* meta) override;
 
 private:
     template <class Member>

--- a/src/Yaml/MetaYamlTraits.h
+++ b/src/Yaml/MetaYamlTraits.h
@@ -27,6 +27,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(Meta::ProtocolMeta*)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Meta::MethodMeta*)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Meta::PropertyMeta*)
 LLVM_YAML_IS_SEQUENCE_VECTOR(Meta::Type*)
+LLVM_YAML_IS_SEQUENCE_VECTOR(Meta::EnumField)
 
 namespace llvm {
 namespace yaml {
@@ -104,7 +105,8 @@ namespace yaml {
             io.enumCase(value, "Struct", Meta::MetaType::Struct);
             io.enumCase(value, "Union", Meta::MetaType::Union);
             io.enumCase(value, "Function", Meta::MetaType::Function);
-            io.enumCase(value, "JsCode", Meta::MetaType::JsCode);
+            io.enumCase(value, "Enum", Meta::MetaType::Enum);
+            io.enumCase(value, "EnumConstant", Meta::MetaType::EnumConstant);
             io.enumCase(value, "Var", Meta::MetaType::Var);
             io.enumCase(value, "Interface", Meta::MetaType::Interface);
             io.enumCase(value, "Protocol", Meta::MetaType::Protocol);
@@ -286,7 +288,6 @@ namespace yaml {
             }
             case Meta::TypeType::TypeEnum: {
                 Meta::EnumType& concreteType = type->as<Meta::EnumType>();
-                io.mapRequired("UnderlyingType", concreteType.underlyingType);
                 io.mapRequired("Name", concreteType.enumMeta->jsName);
                 break;
             }
@@ -417,14 +418,36 @@ namespace yaml {
         }
     };
 
-    // JsCodeMeta *
+    // EnumField
     template <>
-    struct MappingTraits<Meta::JsCodeMeta*> {
+    struct MappingTraits<Meta::EnumField> {
 
-        static void mapping(IO& io, Meta::JsCodeMeta*& meta)
+        static void mapping(IO& io, Meta::EnumField& field)
+        {
+            io.mapRequired(field.name.c_str(), field.value);
+        }
+    };
+
+    // EnumMeta *
+    template <>
+    struct MappingTraits<Meta::EnumMeta*> {
+
+        static void mapping(IO& io, Meta::EnumMeta*& meta)
         {
             mapBaseMeta(io, meta);
-            io.mapRequired("JsCode", meta->jsCode);
+            io.mapRequired("FullNameFields", meta->fullNameFields);
+            io.mapRequired("SwiftNameFields", meta->swiftNameFields);
+        }
+    };
+
+    // EnumConstantMeta *
+    template <>
+    struct MappingTraits<Meta::EnumConstantMeta*> {
+
+        static void mapping(IO& io, Meta::EnumConstantMeta*& meta)
+        {
+            mapBaseMeta(io, meta);
+            io.mapRequired("Value", meta->value);
         }
     };
 
@@ -493,9 +516,14 @@ namespace yaml {
                 MappingTraits<Meta::VarMeta*>::mapping(io, varMeta);
                 break;
             }
-            case Meta::MetaType::JsCode: {
-                Meta::JsCodeMeta* jsCodeMeta = &meta->as<Meta::JsCodeMeta>();
-                MappingTraits<Meta::JsCodeMeta*>::mapping(io, jsCodeMeta);
+            case Meta::MetaType::Enum: {
+                Meta::EnumMeta* enumMeta = &meta->as<Meta::EnumMeta>();
+                MappingTraits<Meta::EnumMeta*>::mapping(io, enumMeta);
+                break;
+            }
+            case Meta::MetaType::EnumConstant: {
+                Meta::EnumConstantMeta* enumConstantMeta = &meta->as<Meta::EnumConstantMeta>();
+                MappingTraits<Meta::EnumConstantMeta*>::mapping(io, enumConstantMeta);
                 break;
             }
             case Meta::MetaType::Interface: {


### PR DESCRIPTION
There is still `JsCodeMeta` in binary structures hierarchy. In meta hierarchy, `JsCodeMeta` is replaced with `EnumMeta` and `EnumConstantMeta`. This way we don't hide information about the underlying declaration in our meta objects graph. In binary serialization step we convert `EnumMeta` and `EnumConstantMeta` (and compile-time constants in the future) to `JsCode` binary structure, so this way the whole `JsCode` concept is binary serialization specific and is invisible for other modules (yaml serializer, tds generator etc.).

It is ready for merge.
