### PR TITLE
Handle CF_RELATED_TYPE attribute

### DIFF
--- a/src/Meta/TypeFactory.cpp
+++ b/src/Meta/TypeFactory.cpp
@@ -410,6 +410,11 @@ static shared_ptr<Type> tryCreateFromBridgedType(const clang::Type* type)
                     string name = bridgeAttr->getBridgedType()->getName().str();
                     return make_shared<BridgedInterfaceType>(name, nullptr);
                 }
+
+                if (clang::ObjCBridgeRelatedAttr* bridgeRelatedAttr = tagDecl->getAttr<clang::ObjCBridgeRelatedAttr>()) {
+                    string name = bridgeRelatedAttr->getRelatedClass()->getName();
+                    return make_shared<BridgedInterfaceType>(name, nullptr);
+                }
             }
         }
     }


### PR DESCRIPTION
There are some `typedef`-s annotated with the `CF_RELATED_TYPE` attribute:

``` objective-c
typedef const struct CF_RELATED_TYPE(NSParagraphStyle,,) __CTParagraphStyle * CTParagraphStyleRef;
typedef const struct CF_RELATED_TYPE(NSTextTab,,) __CTTextTab * CTTextTabRef;
```

https://github.com/llvm-mirror/clang/blob/master/test/FixIt/fixit-objc-bridge-related-attr.m

This PR includes it in the metadata.
