### PR TITLE
Remove ast diagnostic client from buildASTFromCodeWithArgs

### DIFF
--- a/src/HeadersParser/Parser.cpp
+++ b/src/HeadersParser/Parser.cpp
@@ -96,6 +96,8 @@ static std::error_code CreateUmbrellaHeaderForAmbientModules(const std::vector<s
     if (!ast)
         return std::error_code(-1, std::generic_category());
 
+    ast->getDiagnostics().setClient(new clang::IgnoringDiagConsumer);
+
     clang::SmallVector<clang::Module*, 64> modules;
     HeaderSearch& headerSearch = ast->getPreprocessor().getHeaderSearchInfo();
     headerSearch.collectAllModules(modules);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ public:
 
     virtual void HandleTranslationUnit(clang::ASTContext& Context) override
     {
+        Context.getDiagnostics().Reset();
         llvm::SmallVector<clang::Module*, 64> modules;
         _headerSearch.collectAllModules(modules);
         std::list<Meta::Meta*>& metaContainer = _visitor.generateMetadata(Context.getTranslationUnitDecl());


### PR DESCRIPTION
Diagnostics are still printed on the standard error stream.

Module map:

```
module Test {
  umbrella header "Test.h"
  export *
  module * { export * }
// Missing closing brace
```

Standard output:

```
/Users/.../module.modulemap:5:1: error: expected '}'
/Users/.../module.modulemap:1:26: note: to match this '{'
module Test {
            ^
```

Related to: https://github.com/NativeScript/ios-runtime/issues/316
