### PR TITLE
Make protocol initializers optional

### DIFF
--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -347,7 +347,7 @@ std::string DefinitionWriter::writeMethod(MethodMeta* meta, BaseClassMeta* owner
         }
     }
 
-    if (owner->type == MetaType::Protocol && methodDecl.getImplementationControl() == clang::ObjCMethodDecl::ImplementationControl::Optional) {
+    if ((owner->type == MetaType::Protocol && methodDecl.getImplementationControl() == clang::ObjCMethodDecl::ImplementationControl::Optional) || (owner->is(MetaType::Protocol) && meta->getFlags(MethodIsInitializer))) {
         output << "?";
     }
 


### PR DESCRIPTION
Now that Objective-C initializers are expressed as JS constructors (https://github.com/NativeScript/ios-runtime/pull/476), the compilation of classes that implement the following protocol fails:

``` typescript
interface NSCoding {
    initWithCoder(aDecoder: NSCoder): NSCoding;
}

class MyClass implements NSCoding {
    constructor(o: { coder: NSCoder; }); // inherited from NSCoding
}
```

```
error TS2420: Class 'MyClass' incorrectly implements interface 'NSCoding'.
```

This PR makes methods such as `initWithCoder` optional.
