### PR TITLE
Output implicit id type parameters in generic inheritance

### DIFF
--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -55,6 +55,23 @@ std::string DefinitionWriter::getTypeArgumentsStringOrEmpty(const clang::ObjCObj
             }
         }
         output << ">";
+    } else {
+        /* Fill implicit id parameters in similar cases:
+         * @interface MyInterface<ObjectType1, ObjectType2>
+         * @interface MyDerivedInterface : MyInterface
+         */
+        if (clang::ObjCTypeParamList* typeParameters = objectType->getInterface()->getTypeParamListAsWritten()) {
+            if (typeParameters->size()) {
+                output << "<";
+                for (unsigned i = 0; i < typeParameters->size(); i++) {
+                    output << "NSObject";
+                    if (i < typeParameters->size() - 1) {
+                        output << ", ";
+                    }
+                }
+                output << ">";
+            }
+        }
     }
 
     return output.str();


### PR DESCRIPTION
Diff for the Xcode 8 - beta 4 SDK:

``` diff
--- objc!Intents.d.ts 2016-08-03 14:24:35.000000000 
+++ objc!Intents.d.ts 2016-08-03 14:24:09.000000000 
@@ -70,13 +70,13 @@

    constructor(o: { code: INBookRestaurantReservationIntentCode; userActivity: NSUserActivity; });

    initWithCodeUserActivity(code: INBookRestaurantReservationIntentCode, userActivity: NSUserActivity): this;
 }

-declare class INBooleanResolutionResult extends INIntentResolutionResult {
+declare class INBooleanResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INBooleanResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: number): INBooleanResolutionResult;

    static needsValue(): INBooleanResolutionResult; // inherited from INIntentResolutionResult
@@ -105,13 +105,13 @@

    Missed = 2,

    Received = 3
 }

-declare class INCallRecordTypeResolutionResult extends INIntentResolutionResult {
+declare class INCallRecordTypeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCallRecordTypeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INCallRecordType): INCallRecordTypeResolutionResult;

    static needsValue(): INCallRecordTypeResolutionResult; // inherited from INIntentResolutionResult
@@ -194,13 +194,13 @@

    FreshAir = 1,

    RecirculateAir = 2
 }

-declare class INCarAirCirculationModeResolutionResult extends INIntentResolutionResult {
+declare class INCarAirCirculationModeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCarAirCirculationModeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INCarAirCirculationMode): INCarAirCirculationModeResolutionResult;

    static needsValue(): INCarAirCirculationModeResolutionResult; // inherited from INIntentResolutionResult
@@ -234,13 +234,13 @@

    OpticalDrive = 8,

    HardDrive = 9
 }

-declare class INCarAudioSourceResolutionResult extends INIntentResolutionResult {
+declare class INCarAudioSourceResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCarAudioSourceResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INCarAudioSource): INCarAudioSourceResolutionResult;

    static needsValue(): INCarAudioSourceResolutionResult; // inherited from INIntentResolutionResult
@@ -260,13 +260,13 @@

    Front = 1,

    Rear = 2
 }

-declare class INCarDefrosterResolutionResult extends INIntentResolutionResult {
+declare class INCarDefrosterResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCarDefrosterResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INCarDefroster): INCarDefrosterResolutionResult;

    static needsValue(): INCarDefrosterResolutionResult; // inherited from INIntentResolutionResult
@@ -311,13 +311,13 @@

    ThirdRowRight = 10,

    ThirdRow = 11
 }

-declare class INCarSeatResolutionResult extends INIntentResolutionResult {
+declare class INCarSeatResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCarSeatResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INCarSeat): INCarSeatResolutionResult;

    static needsValue(): INCarSeatResolutionResult; // inherited from INIntentResolutionResult
@@ -362,13 +362,13 @@

    initWithAmountCurrencyCode(amount: NSDecimalNumber, currencyCode: string): this;

    initWithCoder(aDecoder: NSCoder): this;
 }

-declare class INCurrencyAmountResolutionResult extends INIntentResolutionResult {
+declare class INCurrencyAmountResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INCurrencyAmountResolutionResult; // inherited from NSObject

    static confirmationRequiredWithCurrencyAmountToConfirm(currencyAmountToConfirm: INCurrencyAmount): INCurrencyAmountResolutionResult;

    static disambiguationWithCurrencyAmountsToDisambiguate(currencyAmountsToDisambiguate: NSArray<INCurrencyAmount>): INCurrencyAmountResolutionResult;
@@ -406,13 +406,13 @@

    initWithCoder(aDecoder: NSCoder): this;

    initWithStartDateComponentsEndDateComponents(startDateComponents: NSDateComponents, endDateComponents: NSDateComponents): this;
 }

-declare class INDateComponentsRangeResolutionResult extends INIntentResolutionResult {
+declare class INDateComponentsRangeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INDateComponentsRangeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithDateComponentsRangeToConfirm(dateComponentsRangeToConfirm: INDateComponentsRange): INDateComponentsRangeResolutionResult;

    static disambiguationWithDateComponentsRangesToDisambiguate(dateComponentsRangesToDisambiguate: NSArray<INDateComponentsRange>): INDateComponentsRangeResolutionResult;
@@ -425,13 +425,13 @@

    static successWithResolvedDateComponentsRange(resolvedDateComponentsRange: INDateComponentsRange): INDateComponentsRangeResolutionResult;

    static unsupported(): INDateComponentsRangeResolutionResult; // inherited from INIntentResolutionResult
 }

-declare class INDateComponentsResolutionResult extends INIntentResolutionResult {
+declare class INDateComponentsResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INDateComponentsResolutionResult; // inherited from NSObject

    static confirmationRequiredWithDateComponentsToConfirm(dateComponentsToConfirm: NSDateComponents): INDateComponentsResolutionResult;

    static disambiguationWithDateComponentsToDisambiguate(dateComponentsToDisambiguate: NSArray<NSDateComponents>): INDateComponentsResolutionResult;
@@ -444,13 +444,13 @@

    static successWithResolvedDateComponents(resolvedDateComponents: NSDateComponents): INDateComponentsResolutionResult;

    static unsupported(): INDateComponentsResolutionResult; // inherited from INIntentResolutionResult
 }

-declare class INDoubleResolutionResult extends INIntentResolutionResult {
+declare class INDoubleResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INDoubleResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: number): INDoubleResolutionResult;

    static needsValue(): INDoubleResolutionResult; // inherited from INIntentResolutionResult
@@ -878,13 +878,13 @@

    encodeWithCoder(aCoder: NSCoder): void;

    initWithCoder(aDecoder: NSCoder): this;
 }

-declare class INIntegerResolutionResult extends INIntentResolutionResult {
+declare class INIntegerResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INIntegerResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: number): INIntegerResolutionResult;

    static needsValue(): INIntegerResolutionResult; // inherited from INIntentResolutionResult
@@ -1178,13 +1178,13 @@

    Flagged = 4,

    Unflagged = 8
 }

-declare class INMessageAttributeOptionsResolutionResult extends INIntentResolutionResult {
+declare class INMessageAttributeOptionsResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INMessageAttributeOptionsResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INMessageAttributeOptions): INMessageAttributeOptionsResolutionResult;

    static needsValue(): INMessageAttributeOptionsResolutionResult; // inherited from INIntentResolutionResult
@@ -1195,13 +1195,13 @@

    static successWithResolvedValue(resolvedValue: INMessageAttributeOptions): INMessageAttributeOptionsResolutionResult;

    static unsupported(): INMessageAttributeOptionsResolutionResult; // inherited from INIntentResolutionResult
 }

-declare class INMessageAttributeResolutionResult extends INIntentResolutionResult {
+declare class INMessageAttributeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INMessageAttributeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INMessageAttribute): INMessageAttributeResolutionResult;

    static needsValue(): INMessageAttributeResolutionResult; // inherited from INIntentResolutionResult
@@ -1515,13 +1515,13 @@

    EmailAddress = 1,

    PhoneNumber = 2
 }

-declare class INPersonResolutionResult extends INIntentResolutionResult {
+declare class INPersonResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INPersonResolutionResult; // inherited from NSObject

    static confirmationRequiredWithPersonToConfirm(personToConfirm: INPerson): INPersonResolutionResult;

    static disambiguationWithPeopleToDisambiguate(peopleToDisambiguate: NSArray<INPerson>): INPersonResolutionResult;
@@ -1599,13 +1599,13 @@
 }
 declare var INPhotosDomainHandling: {

    prototype: INPhotosDomainHandling;
 };

-declare class INPlacemarkResolutionResult extends INIntentResolutionResult {
+declare class INPlacemarkResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INPlacemarkResolutionResult; // inherited from NSObject

    static confirmationRequiredWithPlacemarkToConfirm(placemarkToConfirm: CLPlacemark): INPlacemarkResolutionResult;

    static disambiguationWithPlacemarksToDisambiguate(placemarksToDisambiguate: NSArray<CLPlacemark>): INPlacemarkResolutionResult;
@@ -1692,13 +1692,13 @@

    Satellite = 4,

    DAB = 5
 }

-declare class INRadioTypeResolutionResult extends INIntentResolutionResult {
+declare class INRadioTypeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INRadioTypeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INRadioType): INRadioTypeResolutionResult;

    static needsValue(): INRadioTypeResolutionResult; // inherited from INIntentResolutionResult
@@ -1718,13 +1718,13 @@

    Next = 1,

    Previous = 2
 }

-declare class INRelativeReferenceResolutionResult extends INIntentResolutionResult {
+declare class INRelativeReferenceResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INRelativeReferenceResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INRelativeReference): INRelativeReferenceResolutionResult;

    static needsValue(): INRelativeReferenceResolutionResult; // inherited from INIntentResolutionResult
@@ -1748,13 +1748,13 @@

    Higher = 3,

    Highest = 4
 }

-declare class INRelativeSettingResolutionResult extends INIntentResolutionResult {
+declare class INRelativeSettingResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INRelativeSettingResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INRelativeSetting): INRelativeSettingResolutionResult;

    static needsValue(): INRelativeSettingResolutionResult; // inherited from INIntentResolutionResult
@@ -1998,13 +1998,13 @@

    encodeWithCoder(aCoder: NSCoder): void;

    initWithCoder(aDecoder: NSCoder): this;
 }

-declare class INRestaurantGuestResolutionResult extends INIntentResolutionResult {
+declare class INRestaurantGuestResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INRestaurantGuestResolutionResult; // inherited from NSObject

    static confirmationRequiredWithRestaurantGuestToConfirm(restaurantGuestToConfirm: INRestaurantGuest): INRestaurantGuestResolutionResult;

    static disambiguationWithRestaurantGuestsToDisambiguate(restaurantGuestsToDisambiguate: NSArray<INRestaurantGuest>): INRestaurantGuestResolutionResult;
@@ -2117,13 +2117,13 @@

    Confirmed = 1,

    Denied = 2
 }

-declare class INRestaurantResolutionResult extends INIntentResolutionResult {
+declare class INRestaurantResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INRestaurantResolutionResult; // inherited from NSObject

    static confirmationRequiredWithRestaurantToConfirm(restaurantToConfirm: INRestaurant): INRestaurantResolutionResult;

    static disambiguationWithRestaurantsToDisambiguate(restaurantsToDisambiguate: NSArray<INRestaurant>): INRestaurantResolutionResult;
@@ -3472,13 +3472,13 @@

    retainCount(): number;

    self(): this;
 }

-declare class INSpeakableStringResolutionResult extends INIntentResolutionResult {
+declare class INSpeakableStringResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INSpeakableStringResolutionResult; // inherited from NSObject

    static confirmationRequiredWithStringToConfirm(stringToConfirm: INSpeakableString): INSpeakableStringResolutionResult;

    static disambiguationWithStringsToDisambiguate(stringsToDisambiguate: NSArray<INSpeakableString>): INSpeakableStringResolutionResult;
@@ -3751,13 +3751,13 @@

    FailureOngoingWorkout = 5,

    FailureNoMatchingWorkout = 6
 }

-declare class INStringResolutionResult extends INIntentResolutionResult {
+declare class INStringResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INStringResolutionResult; // inherited from NSObject

    static confirmationRequiredWithStringToConfirm(stringToConfirm: string): INStringResolutionResult;

    static disambiguationWithStringsToDisambiguate(stringsToDisambiguate: NSArray<string>): INStringResolutionResult;
@@ -3770,13 +3770,13 @@

    static successWithResolvedString(resolvedString: string): INStringResolutionResult;

    static unsupported(): INStringResolutionResult; // inherited from INIntentResolutionResult
 }

-declare class INTemperatureResolutionResult extends INIntentResolutionResult {
+declare class INTemperatureResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INTemperatureResolutionResult; // inherited from NSObject

    static confirmationRequiredWithTemperatureToConfirm(temperatureToConfirm: NSMeasurement<NSUnitTemperature>): INTemperatureResolutionResult;

    static disambiguationWithTemperaturesToDisambiguate(temperaturesToDisambiguate: NSArray<NSMeasurement<NSUnitTemperature>>): INTemperatureResolutionResult;
@@ -3869,13 +3869,13 @@

    Joule = 9,

    KiloCalorie = 10
 }

-declare class INWorkoutGoalUnitTypeResolutionResult extends INIntentResolutionResult {
+declare class INWorkoutGoalUnitTypeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INWorkoutGoalUnitTypeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INWorkoutGoalUnitType): INWorkoutGoalUnitTypeResolutionResult;

    static needsValue(): INWorkoutGoalUnitTypeResolutionResult; // inherited from INIntentResolutionResult
@@ -3895,13 +3895,13 @@

    Outdoor = 1,

    Indoor = 2
 }

-declare class INWorkoutLocationTypeResolutionResult extends INIntentResolutionResult {
+declare class INWorkoutLocationTypeResolutionResult extends INIntentResolutionResult<NSObject> {

    static alloc(): INWorkoutLocationTypeResolutionResult; // inherited from NSObject

    static confirmationRequiredWithValueToConfirm(valueToConfirm: INWorkoutLocationType): INWorkoutLocationTypeResolutionResult;

    static needsValue(): INWorkoutLocationTypeResolutionResult; // inherited from INIntentResolutionResult
```
