### PR TITLE
Print members of anonymous enums as global variables instead of skipping them

### DIFF
--- a/src/Meta/MetaEntities.h
+++ b/src/Meta/MetaEntities.h
@@ -238,6 +238,8 @@ public:
 
     std::string value;
 
+    bool isScoped;
+
     virtual void visit(MetaVisitor* visitor) override;
 };
 

--- a/src/Meta/MetaFactory.cpp
+++ b/src/Meta/MetaFactory.cpp
@@ -297,12 +297,17 @@ void MetaFactory::createFromEnum(const clang::EnumDecl& enumeration, EnumMeta& e
     }
 }
 
-void MetaFactory::createFromEnumConstant(const clang::EnumConstantDecl& enumConstant, EnumConstantMeta& enumMeta)
+void MetaFactory::createFromEnumConstant(const clang::EnumConstantDecl& enumConstant, EnumConstantMeta& enumConstantMeta)
 {
-    populateMetaFields(enumConstant, enumMeta);
+    populateMetaFields(enumConstant, enumConstantMeta);
+
     llvm::SmallVector<char, 10> value;
     enumConstant.getInitVal().toString(value, 10, enumConstant.getInitVal().isSigned());
-    enumMeta.value = std::string(value.data(), value.size());
+    enumConstantMeta.value = std::string(value.data(), value.size());
+
+    const clang::EnumDecl* parent = clang::cast<clang::EnumDecl>(enumConstant.getDeclContext());
+    EnumMeta& parentMeta = this->_cache.find(parent)->second.first.get()->as<EnumMeta>();
+    enumConstantMeta.isScoped = !parentMeta.jsName.empty();
 }
 
 void MetaFactory::createFromInterface(const clang::ObjCInterfaceDecl& interface, InterfaceMeta& interfaceMeta)

--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -627,6 +627,14 @@ void DefinitionWriter::visit(PropertyMeta* meta)
 
 void DefinitionWriter::visit(EnumConstantMeta* meta)
 {
+    // The member will be printed by its parent EnumMeta as a TS Enum
+    if (meta->isScoped) {
+        return;
+    }
+
+    _buffer << std::endl;
+    _buffer << "declare const " << meta->jsName << ": number;";
+    _buffer << std::endl;
 }
 
 std::string DefinitionWriter::localizeReference(const std::string& jsName, std::string moduleName)


### PR DESCRIPTION
Related to: https://github.com/NativeScript/ios-runtime/issues/605
