### PR TITLE
Emit the readonly property modifier now that it's supported in TypeScript 2

### DIFF
--- a/src/TypeScript/DefinitionWriter.cpp
+++ b/src/TypeScript/DefinitionWriter.cpp
@@ -241,12 +241,12 @@ void DefinitionWriter::writeProperty(PropertyMeta* propertyMeta, BaseClassMeta* 
             << _docSet.getCommentFor(propertyMeta, owner).toString("\t");
     _buffer << "\t";
 
-    if (!propertyMeta->setter) {
-        _buffer << "/* readonly */ ";
-    }
-
     if (clang::cast<clang::ObjCPropertyDecl>(propertyMeta->declaration)->isClassProperty()) {
         _buffer << "static ";
+    }
+
+    if (!propertyMeta->setter) {
+        _buffer << "readonly ";
     }
 
     bool optOutTypeChecking = false;


### PR DESCRIPTION
http://www.typescriptlang.org/docs/release-notes/typescript-2.0.html#read-only-properties-and-index-signatures

It was previously only a comment.
