### PR TITLE
feat: Rename methods with conflicting jsName-s

### DIFF
--- a/src/Meta/Filters/ResolveGlobalNamesCollisionsFilter.cpp
+++ b/src/Meta/Filters/ResolveGlobalNamesCollisionsFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ResolveGlobalNamesCollisionsFilter.h"
+#include "Meta/MetaFactory.h"
 
 namespace Meta {
 
@@ -27,31 +28,6 @@ static int getPriority(Meta* meta)
         return 1;
     default:
         return 0;
-    }
-}
-
-static std::string renameMeta(MetaType type, std::string& originalJsName, int index = 1)
-{
-    std::string indexStr = index == 1 ? "" : std::to_string(index);
-    switch (type) {
-    case MetaType::Interface:
-        return originalJsName + "Interface" + indexStr;
-    case MetaType::Protocol:
-        return originalJsName + "Protocol" + indexStr;
-    case MetaType::Function:
-        return originalJsName + "Function" + indexStr;
-    case MetaType::Var:
-        return originalJsName + "Var" + indexStr;
-    case MetaType::Struct:
-        return originalJsName + "Struct" + indexStr;
-    case MetaType::Union:
-        return originalJsName + "Union" + indexStr;
-    case MetaType::Enum:
-        return originalJsName + "Enum" + indexStr;
-    case MetaType::EnumConstant:
-        return originalJsName + "Var" + indexStr;
-    default:
-        return originalJsName + "Decl" + indexStr;
     }
 }
 
@@ -86,7 +62,7 @@ void ResolveGlobalNamesCollisionsFilter::filter(std::list<Meta*>& container)
         int index = 1;
         std::string originalJsName = meta->jsName;
         do {
-            meta->jsName = renameMeta(meta->type, originalJsName, index);
+            meta->jsName = MetaFactory::renameMeta(meta->type, originalJsName, index);
             index++;
         } while (!addMeta(meta, false));
     }

--- a/src/Meta/MetaFactory.cpp
+++ b/src/Meta/MetaFactory.cpp
@@ -580,6 +580,33 @@ void MetaFactory::populateBaseClassMetaFields(const clang::ObjCContainerDecl& de
     std::sort(baseClass.instanceProperties.begin(), baseClass.instanceProperties.end(), metasComparerByJsName); // order by jsName
     std::sort(baseClass.staticProperties.begin(), baseClass.staticProperties.end(), metasComparerByJsName); // order by jsName
 }
+    
+std::string MetaFactory::renameMeta(MetaType type, std::string& originalJsName, int index)
+{
+    std::string indexStr = index == 1 ? "" : std::to_string(index);
+    switch (type) {
+        case MetaType::Interface:
+            return originalJsName + "Interface" + indexStr;
+        case MetaType::Protocol:
+            return originalJsName + "Protocol" + indexStr;
+        case MetaType::Function:
+            return originalJsName + "Function" + indexStr;
+        case MetaType::Var:
+            return originalJsName + "Var" + indexStr;
+        case MetaType::Struct:
+            return originalJsName + "Struct" + indexStr;
+        case MetaType::Union:
+            return originalJsName + "Union" + indexStr;
+        case MetaType::Enum:
+            return originalJsName + "Enum" + indexStr;
+        case MetaType::EnumConstant:
+            return originalJsName + "Var" + indexStr;
+        case MetaType::Method:
+            return originalJsName + "Method" + indexStr;
+        default:
+            return originalJsName + "Decl" + indexStr;
+    }
+}
 
 llvm::iterator_range<clang::ObjCProtocolList::iterator> MetaFactory::getProtocols(const clang::ObjCContainerDecl* objCContainer)
 {

--- a/src/Meta/MetaFactory.h
+++ b/src/Meta/MetaFactory.h
@@ -35,6 +35,8 @@ public:
     }
     
     static std::string getTypedefOrOwnName(const clang::TagDecl* tagDecl);
+    
+    static std::string renameMeta(MetaType type, std::string& originalJsName, int index = 1);
 
 private:
     void createFromFunction(const clang::FunctionDecl& function, FunctionMeta& functionMeta);


### PR DESCRIPTION
Same logic as for C-functions is implemented for Objective-C methods - colliding methods are added postfix "-Method(index)". 

For example:

```
-(void)collisionMethodWith:(float)param p1:(int)a p2: (NSString*) p2;
-(void)collisionMethod:(float)param withP1:(int)a p2: (NSString*) p2;
-(void)collisionMethod:(float)param with:(int)a p1P2: (NSString*) p2;
```

are renamed as:

```
collisionMethodWithP1P2(param: number, a: number, p2: string): void;
collisionMethodWithP1P2Method(param: number, a: number, p2: string): void;
collisionMethodWithP1P2Method2(param: number, a: number, p2: string): void;
```